### PR TITLE
Fixing broken link and fixing the readme for the digitalocean example

### DIFF
--- a/examples/digitalocean/README.md
+++ b/examples/digitalocean/README.md
@@ -1,13 +1,13 @@
-# Digital Ocean Droplet launch and setting the Domain records at Digital ocean.
+# Digital Ocean Droplet launch and setting the Domain records at Digital Ocean.
 
-The example launches a Ubuntu 14.04, runs apt-get update and installs nginx. Also demostrates how to create DNS records under Domains at DigitalOcean. 
+The example launches an Ubuntu 14.04, runs apt-get update and installs nginx. Also demonstrates how to create DNS records under Domains at DigitalOcean. 
 
-To run, configure your Digital Ocean provider as described in https://www.terraform.io/docs/providers/digitalocean/index.html
+To run, configure your Digital Ocean provider as described in https://www.terraform.io/docs/providers/do/index.html
 
 ## Prerequisites
 You need to export you DigitalOcean API Token as an environment variable
 
-export DIGITALOCEAN_TOKEN="Put Your Token Here" 
+    export DIGITALOCEAN_TOKEN="Put Your Token Here" 
 
 ## Run this example using:
 


### PR DESCRIPTION
Fixing broken link and fixing the readme for the digitalocean example.

This is the new working link https://www.terraform.io/docs/providers/do/index.html